### PR TITLE
fix randomly generated schema credentials with leading numeric

### DIFF
--- a/deploy/complete/helm-chart/provision/templates/secrets-global.yaml
+++ b/deploy/complete/helm-chart/provision/templates/secrets-global.yaml
@@ -2,7 +2,7 @@
 {{- $oadbWalletPw := .Values.global.oadbWalletPassword | default (randAlphaNum 12) }}
 {{- $oadbName := .Values.global.oadbName | default (printf "mushop%s" (randAlphaNum 12)) }}
 {{- $oadbUser := .Values.global.oadbUser | default (printf "user%s" (randAlphaNum 12)) }}
-{{- $oadbPw := .Values.global.oadbPassword | default (printf "%s" (randAlphaNum 12)) }}
+{{- $oadbPw := .Values.global.oadbPassword | default (printf "%s%s" (randAlpha 1) (randAlphaNum 12)) }}
 
 {{/* If we need to create a global ATP instance to be used by other services */}}
 {{ if .Values.global.osb.atp }}

--- a/deploy/complete/helm-chart/provision/templates/secrets-services.yaml
+++ b/deploy/complete/helm-chart/provision/templates/secrets-services.yaml
@@ -6,7 +6,7 @@
 
 {{- $name := $svcKey.secrets.oadbName | default (printf "mu%s%s" $svcName (randAlphaNum 12)) | trunc 14 }}
 {{- $user := $svcKey.secrets.oadbUser | default (printf "user%s" (randAlphaNum 12)) }}
-{{- $pass := $svcKey.secrets.oadbPassword | default (randAlphaNum 12) }}
+{{- $pass := $svcKey.secrets.oadbPassword | default (printf "%s%s" (randAlpha 1) (randAlphaNum 12)) }}
 {{- $wpass := $svcKey.secrets.oadbWalletPassword | default (randAlphaNum 12) }}
 
 {{/* Check if need to create ATP secrets for the particular service */}}


### PR DESCRIPTION
Fixes problem that arises with a randomly generated password beginning with a numeric character.  The problem cascades into the ATP schema initialization scripts and fails to create the `USER`. Additional steps are necessary to handle this scenario in cases where user-provided password begins with a digit.