### PR TITLE
TF Assets destroy

### DIFF
--- a/deploy/basic/Dockerfile
+++ b/deploy/basic/Dockerfile
@@ -156,7 +156,6 @@ WORKDIR /
 # Copy Services apps
 COPY --from=storefront-builder /app/storefront/build /app/storefront
 COPY --from=api-builder /app/api /app/api
-COPY --from=assets-builder /app/assets /app/assets
 COPY --from=catalogue-builder /catalogue /app/catalogue/catalogue
 
 # Create zip package of the Apps and local images
@@ -167,6 +166,7 @@ COPY deploy/basic/terraform /basic
 COPY src/catalogue/dbdata/atp_mushop_catalogue.sql /basic/scripts
 COPY deploy/basic/httpd.conf /basic/scripts
 COPY deploy/basic/entrypoint.sh /basic/scripts
+COPY --from=assets-builder /app/assets/dist /basic/images
 RUN cp /package/mushop-basic.tar.gz /basic/scripts && \
     cd /basic && zip -r /package/mushop-basic-stack.zip .
 

--- a/deploy/basic/terraform/scripts/node.sh
+++ b/deploy/basic/terraform/scripts/node.sh
@@ -76,11 +76,6 @@ chmod +x /root/entrypoint.sh
 
 # Install node services
 cd /app/api && npm ci --production
-cd /app/assets && npm ci --production
-
-# Deploy assets
-export BUCKET_PAR=$${ASSETS_PAR}
-cd /app/assets && node deploy.js
 
 # Setup app variables
 export OADB_USER=catalogue_user

--- a/deploy/complete/helm-chart/provision/templates/cluster-service-broker.yaml
+++ b/deploy/complete/helm-chart/provision/templates/cluster-service-broker.yaml
@@ -2,7 +2,7 @@
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
 metadata:
-  name: {{.Values.global.osb.name}}
+  name: oci-cluster-service-broker
   annotations:
     "helm.sh/resource-policy": keep
   labels:

--- a/deploy/complete/helm-chart/provision/templates/service-binding-global.yaml
+++ b/deploy/complete/helm-chart/provision/templates/service-binding-global.yaml
@@ -36,4 +36,6 @@ metadata:
 spec:
   instanceRef:
     name: {{ .Values.global.osb.instanceName }}-objectstorage
+  parameters:
+    generatePreAuth: true
 {{ end }}

--- a/deploy/complete/helm-chart/provision/values.yaml
+++ b/deploy/complete/helm-chart/provision/values.yaml
@@ -9,7 +9,7 @@ global:
     # Set object storage namespace, usualy the tenancy name or ocid.
     objectstoragenamespace: ocitenancyname
     # Service broker name (used in the service URL)
-    name: mushop-osb
+    name: oci-broker
     port: 8080
     compartmentId:
     # Service instance name

--- a/src/assets/deploy.js
+++ b/src/assets/deploy.js
@@ -21,6 +21,7 @@ const putImage = (dir, img) => {
     method: 'PUT',
     headers: {
       'Content-Type': mType,
+      'Cache-Control': `max-age=${config.cache.maxAge}, public, no-transform`,
     }
   })
   .then(() => console.log(`PUT Success: ${img}`))

--- a/src/docs/source/includes/_deployment.md
+++ b/src/docs/source/includes/_deployment.md
@@ -262,8 +262,6 @@ secret to the `mushop-utilities` namespace:
       --set global.osb.compartmentId=<compartmentId>
     ```
 
-    > Note that the `oci-credentials` secret was created [previously](#provisioning)
-
 1. It will take a few minutes for the ATP database to provision, and the Wallet binding to become available. Verify `serviceinstances` and `servicebindings` are **READY**:
 
     ```text


### PR DESCRIPTION
Assets now explicitly added to the tf stack. This resolves `BucketNotEmpty` error when destroying stack.

Minor fixes to helm chart provisioning