### PR TITLE
use tags to bypass services that require this dependency

### DIFF
--- a/deploy/complete/helm-chart/mushop/charts/assets/templates/_helpers.tpl
+++ b/deploy/complete/helm-chart/mushop/charts/assets/templates/_helpers.tpl
@@ -51,12 +51,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- $bindingSecret := printf "%s-bucket-par-binding" ($globalOsb.instanceName | default "mushop") -}}
 {{- $bucketSecret := .Values.global.oosBucketSecret | default (printf "%s-bucket" .Release.Name) -}}
 {{- $credentialSecret := .Values.ociAuthSecret | default .Values.global.ociAuthSecret }}
+{{- if $credentialSecret -}}
 - name: REGION
   valueFrom:
     secretKeyRef:
       name: {{ $credentialSecret }}
       key: region
       optional: true
+{{ end }}
 - name: BUCKET_PAR
   valueFrom:
     secretKeyRef:

--- a/deploy/complete/helm-chart/mushop/requirements.yaml
+++ b/deploy/complete/helm-chart/mushop/requirements.yaml
@@ -25,13 +25,15 @@ dependencies:
     condition: session.enabled	
   - name: shipping	
     version: 0.1.0	
-    condition: shipping.enabled	
+    tags:
+      - streaming
   - name: storefront	
     version: 0.1.0	
     condition: storefront.enabled	
   - name: stream	
     version: 0.1.0	
-    condition: stream.enabled	
+    tags:
+      - streaming
   - name: user	
     version: 0.1.0	
     condition: user.enabled

--- a/deploy/complete/helm-chart/mushop/templates/oss-connection-secret.yaml
+++ b/deploy/complete/helm-chart/mushop/templates/oss-connection-secret.yaml
@@ -1,4 +1,5 @@
-{{- if not (or .Values.skip.streaming .Values.global.ossStreamSecret) -}}
+{{- if .Values.tags.streaming -}}
+{{- if not .Values.global.ossStreamSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,4 +14,5 @@ data:
   streamId: {{ .Values.secrets.streams.streamId | default "" | b64enc | default ("" | quote) }}
   region: {{ .Values.secrets.streams.region | default "" | b64enc | default ("" | quote) }}
   {{- end }}
+{{ end }}
 {{ end }}

--- a/deploy/complete/helm-chart/mushop/values.yaml
+++ b/deploy/complete/helm-chart/mushop/values.yaml
@@ -11,9 +11,9 @@ global:
   oosBucketSecret:
 
 # Depending on the scenario, certain resources might need to be skipped.
-# For example, --set skip.streaming=true to disable required streaming secrets
-skip:
-  streaming: false
+# For example, --set tags.streaming=false to disable required streaming manifests
+tags:
+  streaming: true
 
 ingress:
   enabled: true


### PR DESCRIPTION
- Solves issue of having to resolve `.Values.global` with logic within subcharts **requiring** OSS (workshop)