### PR TITLE
add namespace component to auto gen service schemas

### DIFF
--- a/deploy/complete/helm-chart/mushop/charts/carts/templates/oadb-secrets.yaml
+++ b/deploy/complete/helm-chart/mushop/charts/carts/templates/oadb-secrets.yaml
@@ -1,7 +1,7 @@
 {{- $usesOsb := (index (.Values.global | default .Values) "osb").atp | default .Values.osb.atp -}}
 {{- $oadbService := .Values.secrets.oadbService | default .Values.global.oadbService -}}
 {{- $oadbWalletPw := .Values.secrets.oadbWalletPassword | default .Values.global.oadbWalletPassword -}}
-{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_user" .Chart.Name) -}}
+{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_%s_user" .Release.Namespace .Chart.Name ) | trunc 96 -}}
 {{- $oadbPass := .Values.secrets.oadbPassword | default (printf "%s_deFAUlt321#" .Chart.Name) -}}
 
 

--- a/deploy/complete/helm-chart/mushop/charts/catalogue/templates/oadb-secrets.yaml
+++ b/deploy/complete/helm-chart/mushop/charts/catalogue/templates/oadb-secrets.yaml
@@ -1,7 +1,7 @@
 {{- $usesOsb := (index (.Values.global | default .Values) "osb").atp | default .Values.osb.atp -}}
 {{- $oadbService := .Values.secrets.oadbService | default .Values.global.oadbService -}}
 {{- $oadbWalletPw := .Values.secrets.oadbWalletPassword | default .Values.global.oadbWalletPassword -}}
-{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_user" .Chart.Name) -}}
+{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_%s_user" .Release.Namespace .Chart.Name ) | trunc 96 -}}
 {{- $oadbPass := .Values.secrets.oadbPassword | default (printf "%s_deFAUlt321#" .Chart.Name) -}}
 
 

--- a/deploy/complete/helm-chart/mushop/charts/orders/templates/oadb-secrets.yaml
+++ b/deploy/complete/helm-chart/mushop/charts/orders/templates/oadb-secrets.yaml
@@ -1,7 +1,7 @@
 {{- $usesOsb := (index (.Values.global | default .Values) "osb").atp | default .Values.osb.atp -}}
 {{- $oadbService := .Values.secrets.oadbService | default .Values.global.oadbService -}}
 {{- $oadbWalletPw := .Values.secrets.oadbWalletPassword | default .Values.global.oadbWalletPassword -}}
-{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_user" .Chart.Name) -}}
+{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_%s_user" .Release.Namespace .Chart.Name ) | trunc 96 -}}
 {{- $oadbPass := .Values.secrets.oadbPassword | default (printf "%s_deFAUlt321#" .Chart.Name) -}}
 
 

--- a/deploy/complete/helm-chart/mushop/charts/user/templates/oadb-secrets.yaml
+++ b/deploy/complete/helm-chart/mushop/charts/user/templates/oadb-secrets.yaml
@@ -1,6 +1,6 @@
 {{- $usesOsb := (index (.Values.global | default .Values) "osb").atp | default .Values.osb.atp -}}
 {{- $oadbService := .Values.secrets.oadbService | default .Values.global.oadbService -}}
-{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_user" .Chart.Name) -}}
+{{- $oadbUser := .Values.secrets.oadbUser | default (printf "%s_%s_user" .Release.Namespace .Chart.Name ) | trunc 96 -}}
 {{- $oadbPass := .Values.secrets.oadbPassword | default (printf "%s_deFAUlt321#" .Chart.Name) -}}
 
 


### PR DESCRIPTION
Prevents need to manually specify unique `OADB_USER` on shared ATP instance