### PR TITLE
docs for objectstorage namespace

### DIFF
--- a/deploy/complete/helm-chart/provision/values.yaml
+++ b/deploy/complete/helm-chart/provision/values.yaml
@@ -7,7 +7,7 @@ global:
     # Set to true to create a bucket on the object storage service instance
     objectstorage: true
     # Set object storage namespace, usualy the tenancy name or ocid.
-    objectstoragenamespace: ocitenancyname
+    objectstoragenamespace: 
     # Service broker name (used in the service URL)
     name: oci-broker
     port: 8080
@@ -20,11 +20,12 @@ global:
     - orders
     - user
   # Leave values empty to auto-generate them
-  oadbAdminPassword: 
+  oadbAdminPassword:
   oadbWalletPassword:
   oadbName:
   oadbUser:
   oadbPassword:
+  ossStreamName: 
 
 # Each separate service can get its own ATP created
 # by setting the osb.atp=true and providing the compartmentId

--- a/src/docs/source/includes/_deployment.md
+++ b/src/docs/source/includes/_deployment.md
@@ -253,16 +253,18 @@ secret to the `mushop-utilities` namespace:
     helm install provision \
       --namespace mushop \
       --name mushop-provision \
-      --set global.osb.compartmentId=<compartmentId>
+      --set global.osb.compartmentId=<COMPARTMENT_ID> \
+      --set global.osb.objectstoragenamespace=<OBJECT_STORAGE_NAMESPACE>
     ```
 
     ```shell--helm3
     helm install mushop-provision provision \
       --namespace mushop \
-      --set global.osb.compartmentId=<compartmentId>
+      --set global.osb.compartmentId=<COMPARTMENT_ID> \
+      --set global.osb.objectstoragenamespace=<OBJECT_STORAGE_NAMESPACE>
     ```
 
-1. It will take a few minutes for the ATP database to provision, and the Wallet binding to become available. Verify `serviceinstances` and `servicebindings` are **READY**:
+1. It will take a few minutes for the services database to provision, and the respective bindings to become available. Verify `serviceinstances` and `servicebindings` are **READY**:
 
     ```text
     kubectl get serviceinstances -A
@@ -272,9 +274,20 @@ secret to the `mushop-utilities` namespace:
     kubectl get servicebindings -A
     ```
 
+1. A Stream instance will be provisioned by default. One last manual step is required in order to configure the a connection to this service. Create an `oss-connection` secret containing the Stream connection details:
+
+    ```shell
+    kubectl create secret generic oss-connection \
+      --namespace mushop \
+      --from-literal=compartmentId='<COMPARTMENT_OCID>' \
+      --from-literal=region='<REGION_NAME>' \
+      --from-literal=streamId='<STREAM_OCID>' \
+      --from-literal=streamName='<STREAM_NAME>'
+    ```
+
 ## API Gateway, OCI Functions and Email Delivery
 
-Note that this is optional. If you don't want to configure Email Delivery and deploy an API Gateway and the function, skip to the [Deployment](#deployment) section. 
+Note that this is optional. If you don't want to configure Email Delivery and deploy an API Gateway and the function, skip to the [Deployment](#deployment) section.
 
 ### Configure Email Delivery
 

--- a/src/docs/source/includes/_deployment.md
+++ b/src/docs/source/includes/_deployment.md
@@ -172,9 +172,11 @@ Follow the steps outlined below to provision and configure the cluster with clou
       --namespace mushop \
       --from-literal=region=<BUCKET_REGION> \
       --from-literal=name=<BUCKET_NAME> \
-      --from-literal=namespace=<TENANCY_NAME> \
+      --from-literal=namespace=<OBJECT_STORAGE_NAMESPACE> \
       --from-literal=parUrl=<PRE_AUTHENTICATED_REQUEST_URL>
     ```
+
+    > **Object Storage Namespace** may be found with the CLI `oci os ns get` or from the [tenancy information page](https://console.us-ashburn-1.oraclecloud.com/a/tenancy)
 
 1. Verify the secrets are created and available in the `mushop` namespace:
 
@@ -188,6 +190,7 @@ Follow the steps outlined below to provision and configure the cluster with clou
     oadb-connection   Opaque    2      3m
     oadb-wallet       Opaque    7      3m
     oci-credentials   Opaque    6      3m
+    oos-bucket        Opaque    4      3m
     oss-connection    Opaque    4      3m
     ```
 
@@ -263,6 +266,8 @@ secret to the `mushop-utilities` namespace:
       --set global.osb.compartmentId=<COMPARTMENT_ID> \
       --set global.osb.objectstoragenamespace=<OBJECT_STORAGE_NAMESPACE>
     ```
+
+    > **Object Storage Namespace** may be found with the CLI `oci os ns get` or from the [tenancy information page](https://console.us-ashburn-1.oraclecloud.com/a/tenancy)
 
 1. It will take a few minutes for the services database to provision, and the respective bindings to become available. Verify `serviceinstances` and `servicebindings` are **READY**:
 


### PR DESCRIPTION
`global.osb.objectstoragenamespace` is a required value with bucket service instances. The default is now empty, and docs updated to specify accordingly. This prevents errors provisioning the bucket with an incorrect default