### PR TITLE
fix "this"

### DIFF
--- a/src/api/helpers/index.js
+++ b/src/api/helpers/index.js
@@ -66,7 +66,7 @@
    * Inject tracing headers into outgoing requests
    */
   helpers.tracingMiddleware = function (req, res, next) {
-    axios.defaults.headers.common = this.getTracingHeaders(req);
+    axios.defaults.headers.common = helpers.getTracingHeaders(req);
     next();
   };
 


### PR DESCRIPTION
in middleware context, `this` is undefined