### PR TITLE
Bugfix/basic stack use explicit db version

### DIFF
--- a/deploy/basic/terraform/atp.tf
+++ b/deploy/basic/terraform/atp.tf
@@ -14,7 +14,7 @@ resource "oci_database_autonomous_database" "mushop_autonomous_database" {
   is_free_tier             = true
 
   #Optional
-
+  db_version                                     = "19c"
   db_workload                                    = "OLTP"
   display_name                                   = "${var.database_name}${random_id.mushop_id.dec}"
   is_auto_scaling_enabled                        = false


### PR DESCRIPTION
When using MuShop basic stack, use explicit db version in `atp.tf` to prevent the DB going in to an `UNAVAILABLE` state. 

[Docs](https://www.terraform.io/docs/providers/oci/r/database_autonomous_database.html) indicate this is optional, however in many of the regions, without it, ORM executions are having issues. 

Fixes #155 