### PR TITLE
Docs updated to use tabs (switcher) for the provisioning

### DIFF
--- a/deploy/complete/helm-chart/provision/README.md
+++ b/deploy/complete/helm-chart/provision/README.md
@@ -55,7 +55,7 @@ umbrella chart included here. Either complete the setup, or follow these instruc
 1. Install the OCI service broker referencing the credentials above:
 
     ```text
-    helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz \
+    helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz \
       --namespace mushop \
       --set ociCredentials.secretName=oci-credentials \
       --set storage.etcd.useEmbedded=true \

--- a/deploy/complete/helm-chart/provision/README.md
+++ b/deploy/complete/helm-chart/provision/README.md
@@ -55,7 +55,7 @@ umbrella chart included here. Either complete the setup, or follow these instruc
 1. Install the OCI service broker referencing the credentials above:
 
     ```text
-    helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz \
+    helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz \
       --namespace mushop \
       --set ociCredentials.secretName=oci-credentials \
       --set storage.etcd.useEmbedded=true \

--- a/src/catalogue/kubernetes/README.md
+++ b/src/catalogue/kubernetes/README.md
@@ -1,4 +1,5 @@
 # Catalogue (Local Development - Kubernetes)
+
 Local development instructions
 
 ## Requirements
@@ -8,10 +9,10 @@ These steps are necessary if you using a local kubernetes (e.g.: Docker Desktop 
 If you are using a cluster with already deployed the MuShop App, the steps are not necessary.
 
 ### 1) Helm Installed
+
 Installs helm client and the optional svcat cli:
 
-  ```brew update && brew install kubernetes-helm kubernetes-service-catalog-client``` 
-
+  ```brew update && brew install kubernetes-helm kubernetes-service-catalog-client```
 
 Check if the version of the client and the server:
 
@@ -22,6 +23,7 @@ If the server have not initialized, use this command:
 ```helm init --history-max 200```
 
 ### 2) Service Catalog deployed to the cluster used for development
+
 > You can check if the Service Catalog have been already deployed by checking if the pods are in the cluster: ```kubectl get pods -n service-catalog```
 
 Add the Kubernetes Service Catalog helm repository:
@@ -33,6 +35,7 @@ Install the Kubernetes Service Catalog helm chart:
 ```helm install svc-cat/catalog --name catalog --namespace service-catalog```
 
 ### 3) Create a namespace for the development
+
 > You can use the main mushop namespace. Here the instructions to create a separate one.
 > You can check the namespaces on your context using this command: ```kubectl get namespaces --show-labels```
 
@@ -43,12 +46,11 @@ You can optionally label your namespace:
 
 ```kubectl label namespace mushop-dev name=mushop-development```
 
-
-
 ### 4) Service credentials as a Kubernetes secret for the OCI Service Broker
 
 Create secret:
-```
+
+```shell
 kubectl --namespace=mushop-dev create secret generic ocicredentials \
 --from-literal=tenancy=<CUSTOMER_TENANCY_OCID> \
 --from-literal=user=<USER_OCID> \
@@ -60,11 +62,10 @@ kubectl --namespace=mushop-dev create secret generic ocicredentials \
 
 > Note: The passphrase entry is necessary, even if you do not have passphrase for your key, just leave empty
 
-
 ### 5) Install OCI Service Broker
 
-```
-helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz  --name oci-service-broker \
+```shell
+helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz  --name oci-service-broker \
   --namespace mushop-dev \
   --set ociCredentials.secretName=ocicredentials \
   --set storage.etcd.useEmbedded=true \
@@ -72,9 +73,10 @@ helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5
 ```
 
 ### 6) Deploy OCI Service Broker Service
+
 > Note: Check if there's a service broker already running: ```kubectl get clusterservicebrokers```
 
-```
+```shell
 cat <<EOF | kubectl create -f -
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
@@ -109,17 +111,15 @@ EOF
     ```
 
     > ⚠️ The passwords and schema user on this example are just placeholders, please change to your own
-
     > ⚠️ Credentials `oadb_user` and `oadb_pw` are defined here, which are used by services connecting to ATP. The `oadb_service` string is the desired [TNS Name][tns], and follows the naming pattern: `{db.name}_tp`.
-    
 
 ### 8) Config Maps
 
 1. Create a Kubernetes configMap with the sql script that will be used during the first run of the catalogue service.
-```
+
+```shell
 kubectl --namespace=mushop-dev create configmap catalogue-sql --from-file=../dbdata/catalogue.sql
 ```
-
 
 ## Autonomous Database Provisioning
 
@@ -128,7 +128,8 @@ kubectl --namespace=mushop-dev create configmap catalogue-sql --from-file=../dbd
 This step will provision an ATP instance.
 
 Update the file `catalogue-oadb-instance.yaml` with your `compartmentId`. You can also optionally update the dbName and name fields and the db configuration if you want.
-```
+
+```shell
 kubectl --namespace=mushop-dev create -f catalogue-oadb-instance.yaml
 ```
 
@@ -140,29 +141,29 @@ Wait for the status be `Ready` before go to the next step
 ### 2) ATP Binding
 
 This step will create the wallet and store as a Kubernetes Secret.
-```
+
+```shell
 kubectl --namespace=mushop-dev create -f catalogue-oadb-binding.yaml
 ```
-
 
 ## Catalogue Service Deployment
 
 ### 1) Deploy kubernetes service for catalogue service
-```
+
+```shell
 kubectl --namespace=mushop-dev create -f catalogue-svc.yaml
 ```
 
 ### 2) Deploy kubernetes deployment for catalogue service
 
 This step will extract the wallet, create the database schema user, create tables and populate the data on the first run, then will start the catalogue service.
-```
+
+```shell
 kubectl --namespace=mushop-dev create -f catalogue-dep.yaml
 ```
-
 
 ## Local testing
 
 ```kubectl port-forward svc/catalogue 8000:80```
 
 ```curl localhost:8000/catalogue```
-

--- a/src/catalogue/kubernetes/README.md
+++ b/src/catalogue/kubernetes/README.md
@@ -65,7 +65,7 @@ kubectl --namespace=mushop-dev create secret generic ocicredentials \
 ### 5) Install OCI Service Broker
 
 ```shell
-helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz  --name oci-service-broker \
+helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz  --name oci-service-broker \
   --namespace mushop-dev \
   --set ociCredentials.secretName=ocicredentials \
   --set storage.etcd.useEmbedded=true \

--- a/src/docs/content/cloud/deployment.md
+++ b/src/docs/content/cloud/deployment.md
@@ -40,8 +40,10 @@ kubectl create secret generic oci-credentials \
 
 > **NOTE:** The passphrase entry is **required**. If you do not have passphrase for your key, just leave empty.
 
-### Manual Steps
+{{< switcher border=true tabs="Manual Steps|Automated (Using OCI Service Broker)" >}}
 
+<ul>
+<li>
 Follow the steps outlined below to provision and configure the cluster with cloud service connection details.
 
 #### ATP Database
@@ -125,7 +127,8 @@ Follow the steps outlined below to provision and configure the cluster with clou
     oss-connection    Opaque    2      3m
     ```
 
-### Using Service Broker
+</li>
+<li>
 
 As an alternative to manually provisioning, the included [`provision`](https://github.com/oracle-quickstart/oci-cloudnative/tree/master/deploy/complete/helm-chart/provision)
 chart is an application of the open-source [OCI Service Broker](https://github.com/oracle/oci-service-broker)
@@ -155,7 +158,8 @@ secret to the `mushop-utilities` namespace:
 1. Deploy the OCI service broker on your cluster. This is done with the [Oracle OCI Service Broker](https://github.com/oracle/oci-service-broker) helm chart:
 
     ```shell--helm2
-    helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz \
+    helm install \
+      https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz \
       --namespace mushop-utilities \
       --name oci-broker \
       --set ociCredentials.secretName=oci-credentials \
@@ -164,7 +168,8 @@ secret to the `mushop-utilities` namespace:
     ```
 
     ```shell--helm3
-    helm install oci-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz \
+    helm install oci-broker \
+      https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz \
       --namespace mushop-utilities \
       --set ociCredentials.secretName=oci-credentials \
       --set storage.etcd.useEmbedded=true \
@@ -173,12 +178,10 @@ secret to the `mushop-utilities` namespace:
 
     > The above command will deploy the OCI Service Broker using an embedded etcd instance. It is not recommended to deploy the OCI Service Broker using an embedded etcd instance and tls disabled in production environments, instead a separate etcd cluster should be setup and used by the OCI Service Broker.
 
-    {{% alert style="danger" icon="warning" %}}
-    For the mushop `helm` deployment, the OCI Service Broker **MUST** be installed
-    on the same namespace used by the `setup` chart. For convenience, the documentation
-    commands defaults both the `setup` and OCI Service Broker charts to use
-    the `mushop-utilities` namespace.
-    {{% /alert %}}
+    > For the mushop `helm` deployment, the OCI Service Broker **MUST** be installed
+    > on the same namespace used by the `setup` chart. For convenience, the documentation
+    > commands defaults both the `setup` and OCI Service Broker charts to use
+    > the `mushop-utilities` namespace.
   
 1. Next utilize the OCI Service Broker implementation to provision services by installing the included `provision` chart:
 
@@ -222,6 +225,11 @@ secret to the `mushop-utilities` namespace:
     mushop-oadb-wallet-binding   mushop-atp             mushop-oadb-wallet-binding   Ready    1d
     mushop-oss-binding           mushop-oss             mushop-oss-binding           Ready    1d
     ```
+
+</li>
+</ul>
+
+{{< /switcher >}}
 
 ## API Gateway, OCI Functions and Email Delivery
 
@@ -273,6 +281,7 @@ To deploy a function to an app, you can run the following command within the fun
 ```shell
 fn deploy --app [APP_NAME]
 ```
+
 >Note: use `fn -v deploy --app [APP_NAME]` to get verbose output in case you're running into issues.
 
 In the remainder of the document, we will use `mushop-app` for the application name.
@@ -330,7 +339,7 @@ When deployment completes, navigate to it to get the URL for the gateway. Click 
 https://aaaaaaaaa.apigateway.us-ashburn-1.oci.customer-oci.com/newsletter/subscribe
 ```
 
-You will use this URL in `values-dev.yaml` when creating the deployment. 
+You will use this URL in `values-dev.yaml` when creating the deployment.
 
 ## Deployment
 

--- a/src/docs/content/cloud/deployment.md
+++ b/src/docs/content/cloud/deployment.md
@@ -160,7 +160,7 @@ secret to the `mushop-utilities` namespace:
 
     ```shell--helm2
     helm install \
-      https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz \
+      https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz \
       --namespace mushop-utilities \
       --name oci-broker \
       --set ociCredentials.secretName=oci-credentials \
@@ -170,7 +170,7 @@ secret to the `mushop-utilities` namespace:
 
     ```shell--helm3
     helm install oci-broker \
-      https://github.com/oracle/oci-service-broker/releases/download/v1.5.1/oci-service-broker-1.5.1.tgz \
+      https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz \
       --namespace mushop-utilities \
       --set ociCredentials.secretName=oci-credentials \
       --set storage.etcd.useEmbedded=true \

--- a/src/docs/content/cloud/deployment.md
+++ b/src/docs/content/cloud/deployment.md
@@ -320,7 +320,7 @@ The quickest way to create a gateway is through the OCI console:
 1. Make sure **From Scratch** option is selected at the top and enter the following values (you can leave the other values as they are - i.e. no need to enable CORS, Authentication or Rate Limiting):
     - Name: **newsletter-subscription**
     - Path prefix: **/newsletter**
-    - Compartment: <Pick your compartment>
+    - Compartment: < Pick your compartment >
     - Execution log: **Enabled**
     - Log level: **Error**
 1. Click **Next** to define the route

--- a/src/docs/content/cloud/deployment.md
+++ b/src/docs/content/cloud/deployment.md
@@ -19,10 +19,6 @@ Provisioning these services may be done manually of course, but can also be done
 through the use of [OCI Service Broker](https://github.com/oracle/oci-service-broker). You are
 encouraged to explore each approach.
 
-| [Manual](#manual-steps) | [Automated](#using-service-broker) |
-|--|--|
-| Provides steps for provisioning and connecting cloud services to the application | Uses OCI Service Broker to _provision_ **and** _connect_ the Autonomous Transaction Processing database |
-
 In all cases, begin by adding tenancy credentials to manage and
 connect services from within the cluster. Create a secret containing these
 values:
@@ -40,13 +36,18 @@ kubectl create secret generic oci-credentials \
 
 > **NOTE:** The passphrase entry is **required**. If you do not have passphrase for your key, just leave empty.
 
+| Manual | Automated |
+|--|--|
+| Provides steps for provisioning and connecting cloud services to the application | Uses OCI Service Broker to _provision_ **and** _connect_ the Autonomous Transaction Processing database |
+
 {{< switcher border=true tabs="Manual Steps|Automated (Using OCI Service Broker)" >}}
 
 <ul>
 <li>
+
 Follow the steps outlined below to provision and configure the cluster with cloud service connection details.
 
-#### ATP Database
+### ATP Database
 
 1. Provision an Autonomous Transaction Processing (ATP) database. The default options will work well, as will an **Always Free** shape if available. Once **RUNNING** download the DB Connection Wallet and configure secrets as follows:
     - Create `oadb-admin` secret containing the database administrator password. Used once for schema initializations.
@@ -83,7 +84,7 @@ Follow the steps outlined below to provision and configure the cluster with clou
     - `orders`
     - `user`
 
-#### Streaming Service
+### Streaming Service
 
 1. Provision a Streaming instance from the Oracle Cloud Infrastructure [Console](https://console.us-phoenix-1.oraclecloud.com/storage/streaming), and make note of the created Stream `OCID` value. Then create an `oss-connection` secret containing the Stream connection details.
 
@@ -94,7 +95,7 @@ Follow the steps outlined below to provision and configure the cluster with clou
       --from-literal=messageEndpoint='<MESSAGE_ENDPOINT_URL>'
     ```
 
-#### Object Storage
+### Object Storage
 
 1. **Optional**: Provision a **Public** Object Storage Bucket, and create a Pre-Authenticated Request for the bucket. With the information, create a secret called `oos-bucket` as follows:
 
@@ -109,7 +110,7 @@ Follow the steps outlined below to provision and configure the cluster with clou
 
     > **Object Storage Namespace** may be found with the CLI `oci os ns get` or from the [tenancy information page](https://cloud.oracle.com/a/tenancy)
 
-#### Verify
+### Verify
 
 1. Verify the secrets are created and available in the `mushop` namespace:
 
@@ -178,10 +179,10 @@ secret to the `mushop-utilities` namespace:
 
     > The above command will deploy the OCI Service Broker using an embedded etcd instance. It is not recommended to deploy the OCI Service Broker using an embedded etcd instance and tls disabled in production environments, instead a separate etcd cluster should be setup and used by the OCI Service Broker.
 
-    > For the mushop `helm` deployment, the OCI Service Broker **MUST** be installed
-    > on the same namespace used by the `setup` chart. For convenience, the documentation
-    > commands defaults both the `setup` and OCI Service Broker charts to use
-    > the `mushop-utilities` namespace.
+    **Note:** For the mushop `helm` deployment, the OCI Service Broker **MUST** be installed
+    on the same namespace used by the `setup` chart. For convenience, the documentation
+    commands defaults both the `setup` and OCI Service Broker charts to use
+    the `mushop-utilities` namespace.
   
 1. Next utilize the OCI Service Broker implementation to provision services by installing the included `provision` chart:
 

--- a/src/docs/themes/redwood/assets/sass/main.scss
+++ b/src/docs/themes/redwood/assets/sass/main.scss
@@ -264,3 +264,9 @@ pre {
     }
   }
 }
+
+// Switcher (a.k.a simple tabs) Border
+.switcher-border
+{
+    border: 4px solid rgba(121,114,109,.3);
+}

--- a/src/docs/themes/redwood/layouts/shortcodes/switcher.html
+++ b/src/docs/themes/redwood/layouts/shortcodes/switcher.html
@@ -1,8 +1,9 @@
 {{- $uid := index (shuffle (seq 0 300)) 0 -}}
 {{- $left := .Get "left" -}}
+{{- $border := .Get "border" -}}
 {{- $content := .Inner | markdownify -}}
 
-<div uk-grid class="uk-margin-bottom uk-grid-small {{ .Get "class" }}">
+<div uk-grid class="{{ with $border }}switcher-border{{ end }} uk-margin-bottom uk-grid-small {{ .Get "class" }}">
   <div class="uk-width-1-1 {{ with $left }}uk-width-auto@m{{ end }}">
     <ul class="uk-tab{{ with $left }}-left uk-text-large{{ end }}" uk-tab="connect: #switcher-{{ $uid }}">
       {{- with .Get "tabs" -}}

--- a/src/docs/themes/redwood/package-lock.json
+++ b/src/docs/themes/redwood/package-lock.json
@@ -1,666 +1,8 @@
 {
   "name": "mushop-docs-theme",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "mushop-docs-theme",
-      "version": "1.0.0",
-      "hasInstallScript": true,
-      "license": "UPL-1.0",
-      "dependencies": {
-        "autocomplete.js": "^0.37.1",
-        "lunr": "^2.3.8",
-        "mermaid": "^8.4.8",
-        "uikit": "^3.3.3",
-        "whatwg-fetch": "^3.0.0"
-      }
-    },
-    "node_modules/@braintree/sanitize-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz",
-      "integrity": "sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg=="
-    },
-    "node_modules/autocomplete.js": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/autocomplete.js/-/autocomplete.js-0.37.1.tgz",
-      "integrity": "sha512-PgSe9fHYhZEsm/9jggbjtVsGXJkPLvd+9mC7gZJ662vVL5CRWEtm/mIrrzCx0MrNxHVwxD5d00UOn6NsmL2LUQ==",
-      "dependencies": {
-        "immediate": "^3.2.3"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "node_modules/camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dependencies": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
-    "node_modules/clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/crypto-random-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.1.0.tgz",
-      "integrity": "sha512-Tip3yGB+bA7B0W8E4K4mNf2rZhu5r2G5Tb89/utEl5tP1QuLjTF/S9a1b8ifDrR4ORc9Utf6tscpSEtBY3YcPQ==",
-      "dependencies": {
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/css-b64-images": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
-      "integrity": "sha1-QgBdgyBLK0pdk7axpWRBM7WSegI=",
-      "bin": {
-        "css-b64-images": "bin/css-b64-images"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/d3": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-5.15.0.tgz",
-      "integrity": "sha512-C+E80SL2nLLtmykZ6klwYj5rPqB5nlfN5LdWEAVdWPppqTD8taoJi2PxLZjPeYT8FFRR2yucXq+kBlOnnvZeLg==",
-      "dependencies": {
-        "d3-array": "1",
-        "d3-axis": "1",
-        "d3-brush": "1",
-        "d3-chord": "1",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-contour": "1",
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-dsv": "1",
-        "d3-ease": "1",
-        "d3-fetch": "1",
-        "d3-force": "1",
-        "d3-format": "1",
-        "d3-geo": "1",
-        "d3-hierarchy": "1",
-        "d3-interpolate": "1",
-        "d3-path": "1",
-        "d3-polygon": "1",
-        "d3-quadtree": "1",
-        "d3-random": "1",
-        "d3-scale": "2",
-        "d3-scale-chromatic": "1",
-        "d3-selection": "1",
-        "d3-shape": "1",
-        "d3-time": "1",
-        "d3-time-format": "2",
-        "d3-timer": "1",
-        "d3-transition": "1",
-        "d3-voronoi": "1",
-        "d3-zoom": "1"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "node_modules/d3-axis": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
-      "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
-    },
-    "node_modules/d3-brush": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.5.tgz",
-      "integrity": "sha512-rEaJ5gHlgLxXugWjIkolTA0OyMvw8UWU1imYXy1v642XyyswmI1ybKOv05Ft+ewq+TFmdliD3VuK0pRp1VT/5A==",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.6.tgz",
-      "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
-      "dependencies": {
-        "d3-array": "1",
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
-    },
-    "node_modules/d3-color": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
-      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
-    },
-    "node_modules/d3-contour": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
-      "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
-      "dependencies": {
-        "d3-array": "^1.1.1"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
-    },
-    "node_modules/d3-drag": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
-      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-selection": "1"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
-      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
-      "dependencies": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json",
-        "csv2tsv": "bin/dsv2dsv",
-        "dsv2dsv": "bin/dsv2dsv",
-        "dsv2json": "bin/dsv2json",
-        "json2csv": "bin/json2dsv",
-        "json2dsv": "bin/json2dsv",
-        "json2tsv": "bin/json2dsv",
-        "tsv2csv": "bin/dsv2dsv",
-        "tsv2json": "bin/dsv2json"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.6.tgz",
-      "integrity": "sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ=="
-    },
-    "node_modules/d3-fetch": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.2.tgz",
-      "integrity": "sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==",
-      "dependencies": {
-        "d3-dsv": "1"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
-      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
-      "dependencies": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.3.tgz",
-      "integrity": "sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ=="
-    },
-    "node_modules/d3-geo": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.9.tgz",
-      "integrity": "sha512-9edcH6J3s/Aa3KJITWqFJbyB/8q3mMlA9Fi7z6yy+FAYMnRaxmC7jBhUnsINxVWD14GmqX3DK8uk7nV6/Ekt4A==",
-      "dependencies": {
-        "d3-array": "1"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
-      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
-    },
-    "node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-      "dependencies": {
-        "d3-color": "1"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
-    },
-    "node_modules/d3-polygon": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.6.tgz",
-      "integrity": "sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ=="
-    },
-    "node_modules/d3-quadtree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
-    },
-    "node_modules/d3-random": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.2.tgz",
-      "integrity": "sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ=="
-    },
-    "node_modules/d3-scale": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
-      "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
-      "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
-      "dependencies": {
-        "d3-color": "1",
-        "d3-interpolate": "1"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
-      "integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA=="
-    },
-    "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
-    },
-    "node_modules/d3-time-format": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
-      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
-      "dependencies": {
-        "d3-time": "1"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
-    },
-    "node_modules/d3-transition": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
-      "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
-      "dependencies": {
-        "d3-color": "1",
-        "d3-dispatch": "1",
-        "d3-ease": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "^1.1.0",
-        "d3-timer": "1"
-      }
-    },
-    "node_modules/d3-voronoi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
-      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
-    },
-    "node_modules/d3-zoom": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz",
-      "integrity": "sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/dagre-d3": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/dagre-d3/-/dagre-d3-0.6.4.tgz",
-      "integrity": "sha512-e/6jXeCP7/ptlAM48clmX4xTZc5Ek6T6kagS7Oz2HrYSdqcLZFLqpAfh7ldbZRFfxCZVyh61NEPR08UQRVxJzQ==",
-      "dependencies": {
-        "d3": "^5.14",
-        "dagre": "^0.8.5",
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/escaper": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/escaper/-/escaper-2.5.3.tgz",
-      "integrity": "sha512-QGb9sFxBVpbzMggrKTX0ry1oiI4CSDAl9vIL702hzl1jGW8VZs7qfqTRX7WDOjoNDoEVGcEtu1ZOQgReSfT2kQ=="
-    },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
-    "node_modules/html-minifier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
-      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
-      "dependencies": {
-        "camel-case": "^3.0.0",
-        "clean-css": "^4.2.1",
-        "commander": "^2.19.0",
-        "he": "^1.2.0",
-        "param-case": "^2.1.1",
-        "relateurl": "^0.2.7",
-        "uglify-js": "^3.5.1"
-      },
-      "bin": {
-        "html-minifier": "cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-    },
-    "node_modules/is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-    },
-    "node_modules/lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
-    },
-    "node_modules/lunr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
-    },
-    "node_modules/mermaid": {
-      "version": "8.4.8",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.4.8.tgz",
-      "integrity": "sha512-sumTNBFwMX7oMQgogdr3NhgTeQOiwcEsm23rQ4KHGW7tpmvMwER1S+1gjCSSnqlmM/zw7Ga7oesYCYicKboRwQ==",
-      "dependencies": {
-        "@braintree/sanitize-url": "^3.1.0",
-        "crypto-random-string": "^3.0.1",
-        "d3": "^5.7.0",
-        "dagre": "^0.8.4",
-        "dagre-d3": "^0.6.4",
-        "graphlib": "^2.1.7",
-        "he": "^1.2.0",
-        "lodash": "^4.17.11",
-        "minify": "^4.1.1",
-        "moment-mini": "^2.22.1",
-        "scope-css": "^1.2.1"
-      }
-    },
-    "node_modules/minify": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/minify/-/minify-4.1.3.tgz",
-      "integrity": "sha512-ykuscavxivSmVpcCzsXmsVTukWYLUUtPhHj0w2ILvHDGqC+hsuTCihBn9+PJBd58JNvWTNg9132J9nrrI2anzA==",
-      "dependencies": {
-        "clean-css": "^4.1.6",
-        "css-b64-images": "~0.2.5",
-        "debug": "^4.1.0",
-        "html-minifier": "^4.0.0",
-        "terser": "^4.0.0",
-        "try-catch": "^2.0.0",
-        "try-to-catch": "^1.0.2"
-      },
-      "bin": {
-        "minify": "bin/minify.js"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/moment-mini": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.24.0.tgz",
-      "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "dependencies": {
-        "lower-case": "^1.1.1"
-      }
-    },
-    "node_modules/param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dependencies": {
-        "no-case": "^2.2.0"
-      }
-    },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/scope-css": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/scope-css/-/scope-css-1.2.1.tgz",
-      "integrity": "sha512-UjLRmyEYaDNiOS673xlVkZFlVCtckJR/dKgr434VMm7Lb+AOOqXKdAcY7PpGlJYErjXXJzKN7HWo4uRPiZZG0Q==",
-      "dependencies": {
-        "escaper": "^2.5.3",
-        "slugify": "^1.3.1",
-        "strip-css-comments": "^3.0.0"
-      }
-    },
-    "node_modules/slugify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
-      "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/strip-css-comments": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-3.0.0.tgz",
-      "integrity": "sha1-elYl7/iisibPiUehElTaluE9rok=",
-      "dependencies": {
-        "is-regexp": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/terser": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
-      "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/try-catch": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-2.0.1.tgz",
-      "integrity": "sha512-LsOrmObN/2WdM+y2xG+t16vhYrQsnV8wftXIcIOWZhQcBJvKGYuamJGwnU98A7Jxs2oZNkJztXlphEOoA0DWqg==",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/try-to-catch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/try-to-catch/-/try-to-catch-1.1.1.tgz",
-      "integrity": "sha512-ikUlS+/BcImLhNYyIgZcEmq4byc31QpC+46/6Jm5ECWkVFhf8SM2Fp/0pMVXPX6vk45SMCwrP4Taxucne8I0VA=="
-    },
-    "node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
-      "dependencies": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uikit": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uikit/-/uikit-3.3.3.tgz",
-      "integrity": "sha512-YCrjTpti3cVTNjCXo0zeu7Kd/1nWJwIo4YRmLSVJ+MC/FdzWQgmfvby5rXR5TxEETnPamazrFtclPWJQya8W1g=="
-    },
-    "node_modules/upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
-    }
-  },
   "dependencies": {
     "@braintree/sanitize-url": {
       "version": "3.1.0",
@@ -702,23 +44,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
-    "crypto-random-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.1.0.tgz",
-      "integrity": "sha512-Tip3yGB+bA7B0W8E4K4mNf2rZhu5r2G5Tb89/utEl5tP1QuLjTF/S9a1b8ifDrR4ORc9Utf6tscpSEtBY3YcPQ==",
-      "requires": {
-        "type-fest": "^0.8.1"
-      }
-    },
     "css-b64-images": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
       "integrity": "sha1-QgBdgyBLK0pdk7axpWRBM7WSegI="
     },
     "d3": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-5.15.0.tgz",
-      "integrity": "sha512-C+E80SL2nLLtmykZ6klwYj5rPqB5nlfN5LdWEAVdWPppqTD8taoJi2PxLZjPeYT8FFRR2yucXq+kBlOnnvZeLg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-5.16.0.tgz",
+      "integrity": "sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==",
       "requires": {
         "d3-array": "1",
         "d3-axis": "1",
@@ -764,9 +98,9 @@
       "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
     },
     "d3-brush": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.5.tgz",
-      "integrity": "sha512-rEaJ5gHlgLxXugWjIkolTA0OyMvw8UWU1imYXy1v642XyyswmI1ybKOv05Ft+ewq+TFmdliD3VuK0pRp1VT/5A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.6.tgz",
+      "integrity": "sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==",
       "requires": {
         "d3-dispatch": "1",
         "d3-drag": "1",
@@ -790,9 +124,9 @@
       "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "d3-color": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
-      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "d3-contour": {
       "version": "1.3.2",
@@ -827,14 +161,14 @@
       }
     },
     "d3-ease": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.6.tgz",
-      "integrity": "sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
     },
     "d3-fetch": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.2.tgz",
-      "integrity": "sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.2.0.tgz",
+      "integrity": "sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==",
       "requires": {
         "d3-dsv": "1"
       }
@@ -851,14 +185,14 @@
       }
     },
     "d3-format": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.3.tgz",
-      "integrity": "sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "d3-geo": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.9.tgz",
-      "integrity": "sha512-9edcH6J3s/Aa3KJITWqFJbyB/8q3mMlA9Fi7z6yy+FAYMnRaxmC7jBhUnsINxVWD14GmqX3DK8uk7nV6/Ekt4A==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
       "requires": {
         "d3-array": "1"
       }
@@ -919,9 +253,9 @@
       }
     },
     "d3-selection": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
-      "integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
     },
     "d3-shape": {
       "version": "1.3.7",
@@ -937,9 +271,9 @@
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
-      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "requires": {
         "d3-time": "1"
       }
@@ -1000,17 +334,20 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
-    "escaper": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/escaper/-/escaper-2.5.3.tgz",
-      "integrity": "sha512-QGb9sFxBVpbzMggrKTX0ry1oiI4CSDAl9vIL702hzl1jGW8VZs7qfqTRX7WDOjoNDoEVGcEtu1ZOQgReSfT2kQ=="
+    "entity-decode": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/entity-decode/-/entity-decode-2.0.2.tgz",
+      "integrity": "sha512-5CCY/3ci4MC1m2jlumNjWd7VBFt4VfFnmSqSNmVcXq4gxM3Vmarxtt+SvmBnzwLS669MWdVuXboNVj1qN2esVg==",
+      "requires": {
+        "he": "^1.1.1"
+      }
     },
     "graphlib": {
       "version": "2.1.8",
@@ -1052,10 +389,10 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
       "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+    "khroma": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-1.1.0.tgz",
+      "integrity": "sha512-aTO+YX22tYOLEQJYFiatAj1lc5QZ+H5sHWFRBWNCiKwc5NWNUJZyeSeiHEPeURJ2a1GEVYcmyMUwGjjLe5ec5A=="
     },
     "lodash": {
       "version": "4.17.20",
@@ -1068,26 +405,26 @@
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lunr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "mermaid": {
-      "version": "8.4.8",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.4.8.tgz",
-      "integrity": "sha512-sumTNBFwMX7oMQgogdr3NhgTeQOiwcEsm23rQ4KHGW7tpmvMwER1S+1gjCSSnqlmM/zw7Ga7oesYCYicKboRwQ==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.8.4.tgz",
+      "integrity": "sha512-YPn35uEAIrOcsDPjCiKNXXBdO1Aoazsv2zTZjG4+oXa7+tTVUb5sI81NqaTYa47RnoH9Vl4waLlEEJfB8KM9VA==",
       "requires": {
         "@braintree/sanitize-url": "^3.1.0",
-        "crypto-random-string": "^3.0.1",
         "d3": "^5.7.0",
         "dagre": "^0.8.4",
         "dagre-d3": "^0.6.4",
+        "entity-decode": "^2.0.2",
         "graphlib": "^2.1.7",
         "he": "^1.2.0",
-        "lodash": "^4.17.11",
+        "khroma": "^1.1.0",
         "minify": "^4.1.1",
         "moment-mini": "^2.22.1",
-        "scope-css": "^1.2.1"
+        "stylis": "^3.5.2"
       }
     },
     "minify": {
@@ -1145,47 +482,29 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "scope-css": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/scope-css/-/scope-css-1.2.1.tgz",
-      "integrity": "sha512-UjLRmyEYaDNiOS673xlVkZFlVCtckJR/dKgr434VMm7Lb+AOOqXKdAcY7PpGlJYErjXXJzKN7HWo4uRPiZZG0Q==",
-      "requires": {
-        "escaper": "^2.5.3",
-        "slugify": "^1.3.1",
-        "strip-css-comments": "^3.0.0"
-      }
-    },
-    "slugify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
-      "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
-    "strip-css-comments": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-3.0.0.tgz",
-      "integrity": "sha1-elYl7/iisibPiUehElTaluE9rok=",
-      "requires": {
-        "is-regexp": "^1.0.0"
-      }
+    "stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
     },
     "terser": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
-      "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -1202,24 +521,15 @@
       "resolved": "https://registry.npmjs.org/try-to-catch/-/try-to-catch-1.1.1.tgz",
       "integrity": "sha512-ikUlS+/BcImLhNYyIgZcEmq4byc31QpC+46/6Jm5ECWkVFhf8SM2Fp/0pMVXPX6vk45SMCwrP4Taxucne8I0VA=="
     },
-    "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
-    },
     "uglify-js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      }
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.2.tgz",
+      "integrity": "sha512-rWYleAvfJPjduYCt+ELvzybNah/zIkRteGXIBO8X0lteRZPGladF61hFi8tU7qKTsF7u6DUQCtT9k00VlFOgkg=="
     },
     "uikit": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uikit/-/uikit-3.3.3.tgz",
-      "integrity": "sha512-YCrjTpti3cVTNjCXo0zeu7Kd/1nWJwIo4YRmLSVJ+MC/FdzWQgmfvby5rXR5TxEETnPamazrFtclPWJQya8W1g=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/uikit/-/uikit-3.6.3.tgz",
+      "integrity": "sha512-TeTIWtV9K/Q9ee7mdABAeGblxwggp9LSU4HehtqTyIkjNLVBSnKZwkrJTP5853PveJvQVvW5y+t+Gnfqj4gNwg=="
     },
     "upper-case": {
       "version": "1.1.3",
@@ -1227,9 +537,9 @@
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     }
   }
 }

--- a/src/docs/themes/redwood/package.json
+++ b/src/docs/themes/redwood/package.json
@@ -10,9 +10,9 @@
   "license": "UPL-1.0",
   "dependencies": {
     "autocomplete.js": "^0.37.1",
-    "lunr": "^2.3.8",
-    "mermaid": "^8.4.8",
-    "uikit": "^3.3.3",
-    "whatwg-fetch": "^3.0.0"
+    "lunr": "^2.3.9",
+    "mermaid": "^8.8.4",
+    "uikit": "^3.6.3",
+    "whatwg-fetch": "^3.5.0"
   }
 }


### PR DESCRIPTION
- switcher (a.k.a. simple tab) updated to allow optional border
- main.scss updated to include optional border matching tab bar
- deployment.md updated to use tabs to separate "manual" and "automated" options
- OSB updated to 1.5.1 across docs (GH and READMEs)
- some md linting

Verify changes here: https://junior.github.io/oci-quickstart-cloudnative/cloud/deployment/