### PR TITLE
Updates

### DIFF
--- a/deploy/basic/terraform/.terraform.lock.hcl
+++ b/deploy/basic/terraform/.terraform.lock.hcl
@@ -24,20 +24,23 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/hashicorp/oci" {
-  version     = "4.40.0"
-  constraints = ">= 4.40.0"
+  version     = "4.42.0"
+  constraints = ">= 4.42.0"
   hashes = [
-    "h1:gMlxekZi7Qmmosp5ZA3CnQPxxhbmns3K0C617ZaJ+Wo=",
-    "zh:0d839743e27cb56c1af238291c100edb52974e34bbdae2e08eaac765521037f2",
-    "zh:1ee5a0d8559af135eae9977e21c1308a9fdcb727b39b833a484749d5a0255867",
-    "zh:2746ad3d492f6ee2eca42cf61ec43cd68e6d205dd7992ecee3ca935d3ece68df",
-    "zh:6c9faa73ca85e9be376b224411ecad8e2f8923365ecab9409afb9eee2bd4d027",
-    "zh:740cc1bce34269ba367a9a85cc168944a7211b416c5d01847dd6301159e64cc2",
-    "zh:759551b10d4f1488e72a29d119c63d5a7834ca729e008332cfb2524fe5bdce9f",
-    "zh:b7325901a0edf896943bb0efa885629e7c193f703b49c8b4518fda69c39286f9",
-    "zh:c733d120a33b71b260dc105c054963ba19bb9490a3a8613a8bcb26030dc7b31e",
-    "zh:e4d6c60c93068ee699e3d1b1d716219d848a602b3c5f5a9b74699e6e2c2e27c3",
-    "zh:f1e97760ffa5c23f5b5a75c81ddb3821ba838ed33b830787c95aa16407595313",
+    "h1:8fGOROVH9at/jBFhFAg4uDptWVIx0BHKT4lbIeTYDMo=",
+    "h1:JqvwolCJSj+XoUaUMcnzP+000j7g+CHguMtw1r+VK20=",
+    "h1:khL16uNJH90YJxposDaEgKKtpln3RDwF2grO5SplSr0=",
+    "h1:ltDeB+Hygo7sIWPLkf1H+tn3mAhgjQqV0z0t9euXmQc=",
+    "zh:1d23b884fb6024073381d0860935797ae309697a8acea189de275fd27576ba24",
+    "zh:2e1284751e7c560f6ef6e24937914ae9650dff18174e7d0331b803a20758f286",
+    "zh:585304666340994f87b76be00448101e867681f6032271ea0f41152919d2c394",
+    "zh:6bd789fa788458e19064ae221548a6d0954084cb12e191d51aeadd3c707ff47e",
+    "zh:751ca4177c3ab5ecf3023f1cc17ca4c03b122c08bfc36aeed2f18efebad1a4c5",
+    "zh:793636afb392feab2f735dfd6b84c721912caae43c083466ab984905173941ab",
+    "zh:821314b1a3843dde280736de91fc175909660bb38d4220be8dcc948e7057c64e",
+    "zh:92eb5d12ea7315749bdaacf5562ae67a7a59d9eb4b46d0abc0a47d4aa3cec2f8",
+    "zh:c84c18e7ff930c2fd6ac5731bf79b6bd8c8c5c5e569d660ffccc6f76000eac67",
+    "zh:e9435cd87d30640d07806ef0eaeeeab12fed13c9b80741ccd22c20e72b4ec454",
   ]
 }
 

--- a/deploy/basic/terraform/.terraform.lock.hcl
+++ b/deploy/basic/terraform/.terraform.lock.hcl
@@ -24,23 +24,20 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/hashicorp/oci" {
-  version     = "4.36.0"
-  constraints = ">= 4.36.0"
+  version     = "4.40.0"
+  constraints = ">= 4.40.0"
   hashes = [
-    "h1:01cO50NuAKJbF8Zuf0kb4F6grYkwp1bWTXZqL4GLfsg=",
-    "h1:ZuqKSESdEUw2JtTM6JHK788UunPFbws8GF4LOpBhCs0=",
-    "h1:boOLdhbTnk5CUcusPz4Z8jwdfwo0Jdb+0gb6uwwiEzs=",
-    "h1:dDqyMq5e03JchHTNpdfbSKziieU6DSUQW/TrIhVzCMM=",
-    "zh:1427777b7f487625e427aaec3830ffffdb75e0236beefa091dcde789f983f25e",
-    "zh:162726c5c7b74cf87d9d1f736fb9e42fa7fef3bfc73ef5235920fba3ca822931",
-    "zh:2a3a81eda79db8694dd762302886bbf11351e660489eb8fbd789c40ccce1edac",
-    "zh:2f3c38b887115cc60e12421ba31dbc5291b2d90eabc54891f917490a7d63b8ad",
-    "zh:3192af07fe3115037d15305f87e19c85f026f0bcabf881a283b80a8b67d609a0",
-    "zh:5f8595f5c5c3b8f18f9ddcde3ff20c8b6faf6777526562dc7f159a4c2643c34c",
-    "zh:618d0234f925cc8f319c8bf7d07a67a1b9bf2487e53afec87096c05a8b989aef",
-    "zh:8b26b1e89994a07816d47b356880bc01e7b9b56178c16391560b774a5fc8ad45",
-    "zh:abfbb64e6c42ce34cfd18d92b01b20511e1cc68b226d9567d0a6bf33625cc697",
-    "zh:fc7baa714ff3890a62e1190c8641caae882c8af27b5c6629fdc9d2f81857261b",
+    "h1:gMlxekZi7Qmmosp5ZA3CnQPxxhbmns3K0C617ZaJ+Wo=",
+    "zh:0d839743e27cb56c1af238291c100edb52974e34bbdae2e08eaac765521037f2",
+    "zh:1ee5a0d8559af135eae9977e21c1308a9fdcb727b39b833a484749d5a0255867",
+    "zh:2746ad3d492f6ee2eca42cf61ec43cd68e6d205dd7992ecee3ca935d3ece68df",
+    "zh:6c9faa73ca85e9be376b224411ecad8e2f8923365ecab9409afb9eee2bd4d027",
+    "zh:740cc1bce34269ba367a9a85cc168944a7211b416c5d01847dd6301159e64cc2",
+    "zh:759551b10d4f1488e72a29d119c63d5a7834ca729e008332cfb2524fe5bdce9f",
+    "zh:b7325901a0edf896943bb0efa885629e7c193f703b49c8b4518fda69c39286f9",
+    "zh:c733d120a33b71b260dc105c054963ba19bb9490a3a8613a8bcb26030dc7b31e",
+    "zh:e4d6c60c93068ee699e3d1b1d716219d848a602b3c5f5a9b74699e6e2c2e27c3",
+    "zh:f1e97760ffa5c23f5b5a75c81ddb3821ba838ed33b830787c95aa16407595313",
   ]
 }
 

--- a/deploy/basic/terraform/providers.tf
+++ b/deploy/basic/terraform/providers.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     oci = {
       source  = "hashicorp/oci"
-      version = ">= 4.40.0"
+      version = ">= 4.42.0"
       # https://registry.terraform.io/providers/hashicorp/oci/4.40.0
     }
     local = {

--- a/deploy/basic/terraform/providers.tf
+++ b/deploy/basic/terraform/providers.tf
@@ -7,8 +7,8 @@ terraform {
   required_providers {
     oci = {
       source  = "hashicorp/oci"
-      version = ">= 4.36.0"
-      # https://registry.terraform.io/providers/hashicorp/oci/4.36.0
+      version = ">= 4.40.0"
+      # https://registry.terraform.io/providers/hashicorp/oci/4.40.0
     }
     local = {
       source  = "hashicorp/local"

--- a/deploy/basic/terraform/providers.tf
+++ b/deploy/basic/terraform/providers.tf
@@ -8,7 +8,7 @@ terraform {
     oci = {
       source  = "hashicorp/oci"
       version = ">= 4.42.0"
-      # https://registry.terraform.io/providers/hashicorp/oci/4.40.0
+      # https://registry.terraform.io/providers/hashicorp/oci/4.42.0
     }
     local = {
       source  = "hashicorp/local"

--- a/deploy/basic/terraform/storage.tf
+++ b/deploy/basic/terraform/storage.tf
@@ -23,7 +23,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_wallet_preauth" {
   name         = "mushop_wallet_preauth"
   namespace    = data.oci_objectstorage_namespace.user_namespace.namespace
   time_expires = timeadd(timestamp(), "30m")
-  object       = oci_objectstorage_object.mushop_wallet.object
+  object_name       = oci_objectstorage_object.mushop_wallet.object
 }
 
 resource "oci_objectstorage_object" "mushop_basic" {
@@ -38,7 +38,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_lite_preauth" {
   name         = "mushop_lite_preauth"
   namespace    = data.oci_objectstorage_namespace.user_namespace.namespace
   time_expires = timeadd(timestamp(), "30m")
-  object       = oci_objectstorage_object.mushop_basic.object
+  object_name       = oci_objectstorage_object.mushop_basic.object
 }
 
 resource "oci_objectstorage_object" "mushop_media_pars_list" {
@@ -53,7 +53,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_media_pars_list_preauth" {
   name         = "mushop_media_pars_list_preauth"
   namespace    = data.oci_objectstorage_namespace.user_namespace.namespace
   time_expires = timeadd(timestamp(), "30m")
-  object       = oci_objectstorage_object.mushop_media_pars_list.object
+  object_name       = oci_objectstorage_object.mushop_media_pars_list.object
 }
 
 # Static assets bucket
@@ -84,7 +84,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_media_pars_preauth" {
 
   bucket       = oci_objectstorage_bucket.mushop_media.name
   namespace    = oci_objectstorage_bucket.mushop_media.namespace
-  object       = each.value.object
+  object_name       = each.value.object
   name         = "mushop_media_pars_par"
   access_type  = "ObjectRead"
   time_expires = timeadd(timestamp(), "30m")

--- a/deploy/basic/terraform/storage.tf
+++ b/deploy/basic/terraform/storage.tf
@@ -23,7 +23,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_wallet_preauth" {
   name         = "mushop_wallet_preauth"
   namespace    = data.oci_objectstorage_namespace.user_namespace.namespace
   time_expires = timeadd(timestamp(), "30m")
-  object_name       = oci_objectstorage_object.mushop_wallet.object
+  object_name  = oci_objectstorage_object.mushop_wallet.object
 }
 
 resource "oci_objectstorage_object" "mushop_basic" {
@@ -38,7 +38,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_lite_preauth" {
   name         = "mushop_lite_preauth"
   namespace    = data.oci_objectstorage_namespace.user_namespace.namespace
   time_expires = timeadd(timestamp(), "30m")
-  object_name       = oci_objectstorage_object.mushop_basic.object
+  object_name  = oci_objectstorage_object.mushop_basic.object
 }
 
 resource "oci_objectstorage_object" "mushop_media_pars_list" {
@@ -53,7 +53,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_media_pars_list_preauth" {
   name         = "mushop_media_pars_list_preauth"
   namespace    = data.oci_objectstorage_namespace.user_namespace.namespace
   time_expires = timeadd(timestamp(), "30m")
-  object_name       = oci_objectstorage_object.mushop_media_pars_list.object
+  object_name  = oci_objectstorage_object.mushop_media_pars_list.object
 }
 
 # Static assets bucket
@@ -84,7 +84,7 @@ resource "oci_objectstorage_preauthrequest" "mushop_media_pars_preauth" {
 
   bucket       = oci_objectstorage_bucket.mushop_media.name
   namespace    = oci_objectstorage_bucket.mushop_media.namespace
-  object_name       = each.value.object
+  object_name  = each.value.object
   name         = "mushop_media_pars_par"
   access_type  = "ObjectRead"
   time_expires = timeadd(timestamp(), "30m")

--- a/deploy/complete/helm-chart/provision/README.md
+++ b/deploy/complete/helm-chart/provision/README.md
@@ -55,7 +55,7 @@ umbrella chart included here. Either complete the setup, or follow these instruc
 1. Install the OCI service broker referencing the credentials above:
 
     ```text
-    helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz \
+    helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.6.0/oci-service-broker-1.6.0.tgz \
       --namespace mushop \
       --set ociCredentials.secretName=oci-credentials \
       --set storage.etcd.useEmbedded=true \
@@ -64,9 +64,9 @@ umbrella chart included here. Either complete the setup, or follow these instruc
 
     >Note: instead of doing helm install like this, we could copy the .tgz file and use one helm install command to install everything.
 
-    >Another note: The OCI service broker pod will be failing due to a missing secret - that secret is deployed using the provision chart below. If we did the fix above (copy tgz manually and install everyhing using helm), then this wouldn't be happening.
+    >Another note: The OCI service broker pod will be failing due to a missing secret - that secret is deployed using the provision chart below. If we did the fix above (copy tgz manually and install everything using helm), then this wouldn't be happening.
 
-    >Etcd node: The above command will deploy the OCI Service Broker using an embedded etcd instance. It is not recommended to deploy the OCI Service Broker using an embedded etcd instance and tls disabled in production environments, instead a separate etcd cluster should be setup and used by the OCI Sevice Broker.
+    >Etcd node: The above command will deploy the OCI Service Broker using an embedded etcd instance. It is not recommended to deploy the OCI Service Broker using an embedded etcd instance and tls disabled in production environments, instead a separate etcd cluster should be setup and used by the OCI Service Broker.
 
 1. Create a `myvalues.yaml` file with the following information:
 

--- a/deploy/complete/helm-chart/setup/requirements.yaml
+++ b/deploy/complete/helm-chart/setup/requirements.yaml
@@ -1,16 +1,16 @@
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019-2021 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 # 
 
 dependencies:
   # Prometheus
   - name: prometheus
-    version: 14.4.1
+    version: 14.6.0
     condition: prometheus.enabled
     repository: https://prometheus-community.github.io/helm-charts
   # Grafana
   - name: grafana
-    version: 6.14.1
+    version: 6.16.3
     condition: grafana.enabled
     repository: https://grafana.github.io/helm-charts
   # HPA Metrics
@@ -20,7 +20,7 @@ dependencies:
     repository: https://charts.helm.sh/stable
   # Ingress Controller
   - name: ingress-nginx
-    version: 3.34.0
+    version: 4.0.1
     condition: ingress-nginx.enabled
     repository: https://kubernetes.github.io/ingress-nginx
   # Service Catalog
@@ -30,7 +30,7 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/service-catalog 
   # cert-manager
   - name: cert-manager
-    version: 1.4.1
+    version: 1.5.3
     condition: cert-manager.enabled
     repository: https://charts.jetstack.io
   # jenkins

--- a/deploy/complete/helm-chart/setup/templates/NOTES.txt
+++ b/deploy/complete/helm-chart/setup/templates/NOTES.txt
@@ -35,7 +35,7 @@ address to the domain name you included on the values.yaml on the mushop chart.
 ## Grafana
 
 An instance of Grafana was installed with this chart. These instructions describe
-how to access the Grafana application. 
+how to access the Grafana application from local service.
 
 - Get the admin password:
 
@@ -47,6 +47,13 @@ how to access the Grafana application.
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Release.Name }}-grafana 3000:80
 
 - Then open http://localhost:3000
+
+{{- if $ingressConfig.enabled }}
+NOTE: After deploy the MuShop application, a new ingress will be created for Grafana
+  and will be accessible via loadbalancer_host/grafana.
+  Loadbalancer_host can be http://EXTERNAL-IP/grafana or https://domain/grafana
+  depending on the ingress values entered during MuShop chart deployment.
+{{- end }}
 
 {{- end }}
 

--- a/deploy/complete/helm-chart/setup/values.yaml
+++ b/deploy/complete/helm-chart/setup/values.yaml
@@ -22,7 +22,7 @@ prometheus:
 
 # https://github.com/kubernetes-sigs/service-catalog/blob/master/charts/catalog/README.md
 catalog:
-  enabled: true
+  enabled: false
 
 # https://kubernetes.github.io/ingress-nginx/
 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
@@ -110,6 +110,7 @@ grafana:
   grafana.ini:
     server:
       root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
+      serve_from_sub_path: true
   persistence:
     enabled: true
   plugins:

--- a/deploy/complete/terraform/oke-autoscaler.tf
+++ b/deploy/complete/terraform/oke-autoscaler.tf
@@ -255,11 +255,5 @@ resource "kubernetes_deployment" "cluster_autoscaler_deployment" {
     }
   }
 
-  timeouts {
-    create = "1h"
-    update = "1h"
-    delete = "10m"
-  }
-
   depends_on = [oci_containerengine_node_pool.oke_node_pool, local_file.kubeconfig]
 }

--- a/deploy/complete/terraform/oke-autoscaler.tf
+++ b/deploy/complete/terraform/oke-autoscaler.tf
@@ -3,7 +3,7 @@
 # 
 
 locals {
-  cluster_autoscaler_supported_k8s_versions           = ["1.17", "1.18", "1.19", "1.20", "1.21"]
+  cluster_autoscaler_supported_k8s_versions           = ["1.17", "1.18", "1.19"]
   cluster_autoscaler_image_version                    = "2021.03"
   cluster_autoscaler_image                            = "iad.ocir.io/oracle/oci-cluster-autoscaler:${local.k8s_major_minor_version}-${local.cluster_autoscaler_image_version}"
   cluster_autoscaler_app_version                      = 4
@@ -253,6 +253,12 @@ resource "kubernetes_deployment" "cluster_autoscaler_deployment" {
         }
       }
     }
+  }
+
+  timeouts {
+    create = "1h"
+    update = "1h"
+    delete = "10m"
   }
 
   depends_on = [oci_containerengine_node_pool.oke_node_pool, local_file.kubeconfig]

--- a/src/catalogue/kubernetes/README.md
+++ b/src/catalogue/kubernetes/README.md
@@ -65,7 +65,7 @@ kubectl --namespace=mushop-dev create secret generic ocicredentials \
 ### 5) Install OCI Service Broker
 
 ```shell
-helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz  --name oci-service-broker \
+helm install https://github.com/oracle/oci-service-broker/releases/download/v1.6.0/oci-service-broker-1.6.0.tgz  --name oci-service-broker \
   --namespace mushop-dev \
   --set ociCredentials.secretName=ocicredentials \
   --set storage.etcd.useEmbedded=true \

--- a/src/docs/content/cloud/deployment.md
+++ b/src/docs/content/cloud/deployment.md
@@ -135,6 +135,8 @@ As an alternative to manually provisioning, the included [`provision`](https://g
 chart is an application of the open-source [OCI Service Broker](https://github.com/oracle/oci-service-broker)
 for _provisioning_ Oracle Cloud Infrastructure services. This implementation utilizes [Open Service Broker](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md) in Oracle Container Engine for Kubernetes or in other Kubernetes clusters.
 
+> **Note:** The OCI Service Broker depends on the Service Catalog, so make sure that you run the setup chart with the `catalog.enabled=true`.
+
 ```shell--linux-macos
 cd deploy/complete/helm-chart
 ```
@@ -160,7 +162,7 @@ secret to the `mushop-utilities` namespace:
 
     ```shell--helm2
     helm install \
-      https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz \
+      https://github.com/oracle/oci-service-broker/releases/download/v1.6.0/oci-service-broker-1.6.0.tgz \
       --namespace mushop-utilities \
       --name oci-broker \
       --set ociCredentials.secretName=oci-credentials \
@@ -170,7 +172,7 @@ secret to the `mushop-utilities` namespace:
 
     ```shell--helm3
     helm install oci-broker \
-      https://github.com/oracle/oci-service-broker/releases/download/v1.5.2/oci-service-broker-1.5.2.tgz \
+      https://github.com/oracle/oci-service-broker/releases/download/v1.6.0/oci-service-broker-1.6.0.tgz \
       --namespace mushop-utilities \
       --set ociCredentials.secretName=oci-credentials \
       --set storage.etcd.useEmbedded=true \

--- a/src/docs/layouts/shortcodes/content/setup.md
+++ b/src/docs/layouts/shortcodes/content/setup.md
@@ -1,3 +1,5 @@
+#
+
 MuShop provides an umbrella helm chart called `setup`, which includes several
 _recommended_ installations on the cluster. These represent common 3rd party
 services, which integrate with Oracle Cloud Infrastructure or enable certain
@@ -9,8 +11,8 @@ application features.
 | [Grafana](https://github.com/helm/charts/blob/master/stable/grafana/README.md) | Infrastructure/service visualization dashboards | `grafana.enabled` | true |
 | [Metrics Server](https://github.com/helm/charts/blob/master/stable/metrics-server/README.md) | Support for Horizontal Pod Autoscaling | `metrics-server.enabled` | true |
 | [Ingress Nginx](https://kubernetes.github.io/ingress-nginx/) | Ingress controller and public Load Balancer | `ingress-nginx.enabled` | true |
-| [Service Catalog](https://github.com/kubernetes-sigs/service-catalog/blob/master/charts/catalog/README.md) | Service Catalog chart utilized by Oracle Service Broker | `catalog.enabled` | true |
 | [Cert Manager](https://github.com/jetstack/cert-manager/blob/master/README.md) | x509 certificate management for Kubernetes | `cert-manager.enabled` | true |
+| [Service Catalog](https://github.com/kubernetes-sigs/service-catalog/blob/master/charts/catalog/README.md) | Service Catalog chart utilized by Oracle Service Broker | `catalog.enabled` | false |
 | [Jenkins](https://github.com/helm/charts/blob/master/stable/jenkins/README.md) | Jenkins automation server on Kubernetes | `jenkins.enabled` | false |
 
 > Dependencies installed with `setup` chart. **NOTE** as these are very common installations, each may be disabled as needed to resolve conflicts.
@@ -39,13 +41,22 @@ From `deploy/complete/helm-chart` directory:
     helm install mushop-utils setup \
       --namespace mushop-utilities
     ```
->  **OPTIONAL** The Jenkins automation server can be enabled by setting `jenkins.enabled` to `true` in `values.yaml` or by adding the command line flag `--set jenkins.enabled=true` in the `helm install` command above.
 
-  ```shell--helm3
-  helm install mushop-utils setup \
-    --namespace mushop-utilities \
-    --set jenkins.enabled=true
-  ```
+    > **OPTIONAL** If will be provisioning ATP, Stream and Object Storage with OCI Service Broker, you should enable the Service Catalog  `catalog.enabled` to `true` in `values.yaml` or by adding the command line flag `--set catalog.enabled=true` in the `helm install` command above.
+
+    ```shell--helm3
+    helm install mushop-utils setup \
+      --namespace mushop-utilities \
+      --set catalog.enabled=true
+    ```
+
+    > **OPTIONAL** The Jenkins automation server can be enabled by setting `jenkins.enabled` to `true` in `values.yaml` or by adding the command line flag `--set jenkins.enabled=true` in the `helm install` command above.
+
+    ```shell--helm3
+    helm install mushop-utils setup \
+      --namespace mushop-utilities \
+      --set jenkins.enabled=true
+    ```
 
 1. **NOTE** the public `EXTERNAL-IP` assigned to the ingress controller load balancer:
 

--- a/src/docs/layouts/shortcodes/content/setup.md
+++ b/src/docs/layouts/shortcodes/content/setup.md
@@ -42,7 +42,7 @@ From `deploy/complete/helm-chart` directory:
       --namespace mushop-utilities
     ```
 
-    > **OPTIONAL** If will be provisioning ATP, Stream and Object Storage with OCI Service Broker, you should enable the Service Catalog  `catalog.enabled` to `true` in `values.yaml` or by adding the command line flag `--set catalog.enabled=true` in the `helm install` command above.
+    > **OPTIONAL** In case you are provisioning ATP, Stream, and Object Storage with **OCI Service Broker**. In that case, you should enable the Service Catalog `catalog.enabled` to `true` in `values.yaml` or by adding the command line flag `--set catalog.enabled=true` in the `helm install` command above.
 
     ```shell--helm3
     helm install mushop-utils setup \


### PR DESCRIPTION
Complete:

- Update Grafana notes for port-forward option
- Update Grafana config to allow run from svc directly and not only from the ingress
- Update supported versions for Cluster Autoscaler

Basic:

- Update Terraform OCI provider version
- Update Storage resource with the TF OCI provider update

Fix Issue #291 