### PR TITLE
Update controller-metrics port from 9913 to 10254

### DIFF
--- a/deploy/complete/helm-chart/setup/values.yaml
+++ b/deploy/complete/helm-chart/setup/values.yaml
@@ -18,7 +18,7 @@ prometheus:
       scrape_interval: 5s
       static_configs:
         - targets:
-          - {{ .Release.Name }}-ingress-nginx-controller-metrics:9913
+          - {{ .Release.Name }}-ingress-nginx-controller-metrics:10254
   nodeExporter:
     hostRootfs: false
 


### PR DESCRIPTION
ingress-nginx-controller-metrics port is currently 10254, not 9913. It is required to view NGINX Ingress controller dashboard in Grafana. 

# This is the result from my env that is installed yesterday.
winter@cloudshell:~ (ap-chuncheon-1)$ kubectl get svc -n mushop-utilities
NAME                                              TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                      AGE
...
mushop-utils-ingress-nginx-controller-metrics     ClusterIP      10.96.73.104    <none>           10254/TCP                    21h
mushop-utils-kube-state-metrics                   ClusterIP      10.96.223.49    <none>           8080/TCP                     21h
...

# This is official README for nginx ingress helm chart.
https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
controller.metrics.port	int	10254