### PR TITLE
Update service-catalog repository.

### DIFF
--- a/deploy/complete/helm-chart/setup/requirements.yaml
+++ b/deploy/complete/helm-chart/setup/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   - name: catalog
     version: 0.3.1
     condition: catalog.enabled
-    repository: https://kubernetes-sigs.github.io/service-catalog 
+    repository: https://kubernetes-retired.github.io/service-catalog 
   # cert-manager
   - name: cert-manager
     version: 1.7.1


### PR DESCRIPTION
https://kubernetes-sigs.github.io/service-catalog url is disappeared.

When do helm dependency update with old value, 'https://kubernetes-sigs.github.io/service-catalog, the following error is occurred. 
$ helm dependency update deploy/complete/helm-chart/setup
Getting updates for unmanaged Helm repositories...
...Unable to get an update from the "https://kubernetes-sigs.github.io/service-catalog" chart repository:
        failed to fetch https://kubernetes-sigs.github.io/service-catalog/index.yaml : 404 Not Found
...Successfully got an update from the "https://kubernetes-sigs.github.io/metrics-server" chart repository
...Successfully got an update from the "https://kubernetes.github.io/ingress-nginx" chart repository
...Successfully got an update from the "https://grafana.github.io/helm-charts" chart repository
...Successfully got an update from the "https://prometheus-community.github.io/helm-charts" chart repository
...Successfully got an update from the "https://charts.helm.sh/stable" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "jetstack" chart repository
Update Complete. ⎈Happy Helming!⎈
Error: no cached repository for helm-manager-f756cbfe15744628285d5c07f0f9d688e1150c52b27024016049b451a84d1714 found. (try 'helm repo update'): open /home/donghee/.cache/helm/repository/helm-manager-f756cbfe15744628285d5c07f0f9d688e1150c52b27024016049b451a84d1714-index.yaml: no such file or directory